### PR TITLE
Updated yarn version info URL

### DIFF
--- a/templates/forge/gradle.properties
+++ b/templates/forge/gradle.properties
@@ -12,7 +12,7 @@ loom.platform=forge
     minecraft_version=@MINECRAFT@
     # forge version, latest version can be found on https://files.minecraftforge.net/
     forge_version=@FORGE@
-    # yarn, latest version can be found on https://fabricmc.net/use
+    # yarn, latest version can be found on https://fabricmc.net/develop/
     yarn_mappings=@YARN_MAPPINGS@
 
 # Mod Properties


### PR DESCRIPTION
Old URL takes you to the fabric installation page for non developers